### PR TITLE
Use {withr} to manage local tempfile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Suggests:
     processx,
     redux,
     testthat (>= 3.0.0),
-    rush (>= 0.1.2)
+    rush (>= 0.1.2),
+    withr
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/tests/testthat/test_mlr_callbacks.R
+++ b/tests/testthat/test_mlr_callbacks.R
@@ -1,18 +1,18 @@
 test_that("backup batch callback works", {
-  on.exit(unlink("./archive.rds"))
+  archive = withr::local_tempfile()
 
   instance = OptimInstanceBatchSingleCrit$new(
     objective = OBJ_1D,
     search_space = PS_1D,
     terminator = trm("evals", n_evals = 10),
-    callbacks = clbk("bbotk.backup", path = "./archive.rds"),
+    callbacks = clbk("bbotk.backup", path = archive),
   )
 
   optimizer = opt("random_search")
   optimizer$optimize(instance)
 
-  expect_file_exists("./archive.rds")
-  expect_data_table(readRDS("./archive.rds"))
+  expect_file_exists(archive)
+  expect_data_table(readRDS(archive))
 })
 
 test_that("async callback works", {


### PR DESCRIPTION
Came to my attention because we run tests in an environment where local paths (as `./archive.rds` here) are not writable.

That's of course our own fault, but using `withr::local_tempfile()` over an `on.exit()` approach as here has benefits on its own.

Note that because {testthat} Imports {withr}, this does not functionally affect the net of dependencies for the package.